### PR TITLE
Fixes parsing of track w/o elevation in track points

### DIFF
--- a/Sources/GPXKit/GPXFileParser.swift
+++ b/Sources/GPXKit/GPXFileParser.swift
@@ -78,9 +78,13 @@ final public class GPXFileParser {
 internal extension TrackPoint {
 	init?(trackNode: XMLNode) {
 		guard let lat = trackNode.latitude,
-			let lon = trackNode.longitude,
-			let ele = trackNode.childFor(.elevation)?.elevation else { return nil }
-		self.coordinate = Coordinate(latitude: lat, longitude: lon, elevation: ele)
+			let lon = trackNode.longitude
+		else { return nil }
+        self.coordinate = Coordinate(
+            latitude: lat,
+            longitude: lon,
+            elevation: trackNode.childFor(.elevation)?.elevation ?? .zero
+        )
 		self.date = trackNode.childFor(.time)?.date
 		self.power = trackNode.childFor(.extensions)?.childFor(.power)?.power
 	}

--- a/Tests/GPXKitTests/GPXParserTests.swift
+++ b/Tests/GPXKitTests/GPXParserTests.swift
@@ -129,6 +129,36 @@ class GPXParserTests: XCTestCase {
                                 trackPoints: expected), result!)
     }
 
+    func testParsingTrackWithoutElevation() {
+        parseXML("""
+        <?xml version="1.0" encoding="UTF-8"?>
+        <gpx creator="StravaGPX" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd http://www.garmin.com/xmlschemas/GpxExtensions/v3 http://www.garmin.com/xmlschemas/GpxExtensionsv3.xsd http://www.garmin.com/xmlschemas/TrackPointExtension/v1 http://www.garmin.com/xmlschemas/TrackPointExtensionv1.xsd" version="1.1" xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3">
+            <metadata>
+            </metadata>
+            <trk>
+                <name>Haus- und Seenrunde Ausdauer</name>
+                <type>1</type>
+                <trkseg>
+                    <trkpt lat="51.2760600" lon="12.3769500"></trkpt>
+                    <trkpt lat="51.2760420" lon="12.3769760"></trkpt>
+                </trkseg>
+            </trk>
+        </gpx>
+        """)
+
+        let expected = [
+            TrackPoint(coordinate: Coordinate(latitude: 51.2760600, longitude: 12.3769500, elevation: 0),
+                       date: nil),
+            TrackPoint(coordinate: Coordinate(latitude: 51.2760420, longitude: 12.3769760, elevation: 0),
+                       date: nil)
+        ]
+
+        assertTracksAreEqual(GPXTrack(date: nil,
+                                      title: "Haus- und Seenrunde Ausdauer",
+                                      trackPoints: expected), result!)
+
+    }
+
     func testTrackLength() throws {
         parseXML(sampleGPX)
 


### PR DESCRIPTION
`TrackPoint`s without an `ele` child node currently get skipped. This PR fixes that issue by setting an elevation of `0` to them.