### PR TITLE
Use date formatter format for garmin when available

### DIFF
--- a/Sources/GPXKit/ISO8601DateFormatter.swift
+++ b/Sources/GPXKit/ISO8601DateFormatter.swift
@@ -10,7 +10,7 @@ extension ISO8601DateFormatter {
     static var importingFractionalSeconds: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
         if #available(macOS 10.13, iOS 12, tvOS 11.0, *) {
-            formatter.formatOptions = .withFractionalSeconds
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
         } else {
             formatter.formatOptions = .withInternetDateTime
         }

--- a/Tests/GPXKitTests/GPXParserTests.swift
+++ b/Tests/GPXKitTests/GPXParserTests.swift
@@ -222,6 +222,14 @@ class GPXParserTests: XCTestCase {
         ), XCTUnwrap(result))
     }
 
+    func testTrackPointsDateWithFraction() throws {
+        parseXML(sampleGPX)
+
+        let date = try XCTUnwrap(result?.trackPoints.first?.date)
+        
+        XCTAssertEqual(1351121380, date.timeIntervalSince1970)
+    }
+
     func testTrackLength() throws {
         parseXML(sampleGPX)
 


### PR DESCRIPTION
It appears ISO8601DateFormatter importingFractionalSeconds with the option withFractionalSeconds is not enough to parse default (at least for Garmin) GPX date, proper option set is withFractionalSeconds AND withInternetDateTime (which is already in use without  withFractionalSeconds pre iOS 12)

This is the first track Points's date from the sample: 2023-05-04T04:13:40.000Z