### PR TITLE
Multiple tracks and segments

### DIFF
--- a/Sources/GPXKit/CombineSupport.swift
+++ b/Sources/GPXKit/CombineSupport.swift
@@ -7,7 +7,7 @@ extension GPXFileParser {
     /// Publisher for bridging into Combine.
     ///
     /// An AnyPublisher with Output `GPXTrack` and Failure of `GPXParserError`.
-    public var publisher: AnyPublisher<GPXTrack, GPXParserError> {
+    public var publisher: AnyPublisher<GPX, GPXParserError> {
         Future { promise in
             promise(self.parse())
         }.eraseToAnyPublisher()
@@ -28,7 +28,7 @@ extension GPXFileParser {
     ///        /// handle parsing error
     ///    }
     /// ```
-    public class func load(from url: URL) -> AnyPublisher<GPXTrack, GPXParserError> {
+    public class func load(from url: URL) -> AnyPublisher<GPX, GPXParserError> {
         guard let parser = GPXFileParser(url: url) else { return Fail(error: GPXParserError.invalidGPX).eraseToAnyPublisher() }
         return parser.publisher
     }
@@ -48,7 +48,7 @@ extension GPXFileParser {
     ///        /// handle parsing error
     ///    }
     /// ```
-    public class func load(from data: Data) -> AnyPublisher<GPXTrack, GPXParserError> {
+    public class func load(from data: Data) -> AnyPublisher<GPX, GPXParserError> {
         guard let parser = GPXFileParser(data: data) else { return Fail(error: GPXParserError.invalidGPX).eraseToAnyPublisher() }
         return parser.publisher
     }

--- a/Sources/GPXKit/GPX.swift
+++ b/Sources/GPXKit/GPX.swift
@@ -8,7 +8,8 @@ public enum ElevationSmoothing: Sendable, Hashable {
     case combined(smoothingSampleCount: Int, maxGradeDelta: Double)
 }
 
-/// A value describing a track of geo locations. It has the recorded ``TrackPoint``s, along with metadata of the track, such as recorded date, title, elevation gain, distance, height-map and bounds.
+
+/// A value describing a track of geo locations. It has the recorded ``GPXPoint``s, along with metadata of the track, such as recorded date, title, elevation gain, distance, height-map and bounds.
 public struct GPX: Hashable, Sendable {
     /// Optional date stamp of the gpx track
     public var date: Date?
@@ -19,7 +20,7 @@ public struct GPX: Hashable, Sendable {
     /// Description of the gpx track
     public var description: String?
     /// Array of latitude/longitude/elevation stream values
-    public var trackPoints: [TrackPoint]
+    public var trackPoints: [GPXPoint]
     /// `TrackGraph` containing elevation gain, overall distance and the height map of a track.
     public var graph: TrackGraph
     /// The bounding box enclosing the track
@@ -32,9 +33,9 @@ public struct GPX: Hashable, Sendable {
     ///   - date: The date stamp of the track. Defaults to nil.
     ///   - waypoints: Array of ``Waypoint`` values. Defaults to nil.
     ///   - title: String describing the track.
-    ///   - trackPoints: Array of ``TrackPoint``s describing the route.
+    ///   - trackPoints: Array of ``GPXPoint``s describing the route.
     ///   - keywords: Array of `String`s with keywords. Default is an empty array (no keywords).
-    public init(date: Date? = nil, waypoints: [Waypoint]? = nil, title: String, description: String? = nil, trackPoints: [TrackPoint], keywords: [String] = []) {
+    public init(date: Date? = nil, waypoints: [Waypoint]? = nil, title: String, description: String? = nil, trackPoints: [GPXPoint], keywords: [String] = []) {
         self.date = date
         self.waypoints = waypoints
         self.title = title
@@ -50,10 +51,10 @@ public struct GPX: Hashable, Sendable {
     ///   - date: The date stamp of the track. Defaults to nil.
     ///   - waypoints: Array of ``Waypoint`` values. Defaults to nil.
     ///   - title: String describing the track.
-    ///   - trackPoints: Array of ``TrackPoint``s describing the route.
+    ///   - trackPoints: Array of ``GPXPoint``s describing the route.
     ///   - keywords: Array of `String`s with keywords. Default is an empty array (no keywords).
     ///   - elevationSmoothing: The ``ElevationSmoothing`` in meters for the grade segments. Defaults to ``ElevationSmoothing/segmentation(_:)`` with 50 meters.
-    public init(date: Date? = nil, waypoints: [Waypoint]? = nil, title: String, description: String? = nil, trackPoints: [TrackPoint], keywords: [String] = [], elevationSmoothing: ElevationSmoothing = .segmentation(50)) throws {
+    public init(date: Date? = nil, waypoints: [Waypoint]? = nil, title: String, description: String? = nil, trackPoints: [GPXPoint], keywords: [String] = [], elevationSmoothing: ElevationSmoothing = .segmentation(50)) throws {
         self.date = date
         self.waypoints = waypoints
         self.title = title

--- a/Sources/GPXKit/GPX.swift
+++ b/Sources/GPXKit/GPX.swift
@@ -9,7 +9,7 @@ public enum ElevationSmoothing: Sendable, Hashable {
 }
 
 /// A value describing a track of geo locations. It has the recorded ``TrackPoint``s, along with metadata of the track, such as recorded date, title, elevation gain, distance, height-map and bounds.
-public struct GPXTrack: Hashable, Sendable {
+public struct GPX: Hashable, Sendable {
     /// Optional date stamp of the gpx track
     public var date: Date?
     /// Waypoint defined for the gpx

--- a/Sources/GPXKit/GPX.swift
+++ b/Sources/GPXKit/GPX.swift
@@ -19,28 +19,29 @@ public struct GPX: Hashable, Sendable {
     public var title: String
     /// Description of the gpx track
     public var description: String?
-    /// Array of latitude/longitude/elevation stream values
-    public var trackPoints: [GPXPoint]
+    /// Array of tracks
+    public var tracks: [GPXTrack]
     /// `TrackGraph` containing elevation gain, overall distance and the height map of a track.
     public var graph: TrackGraph
     /// The bounding box enclosing the track
     public var bounds: GeoBounds
     /// Keywords describing a gpx track
     public var keywords: [String]
-
+    
     /// Initializes a GPXTrack.
     /// - Parameters:
     ///   - date: The date stamp of the track. Defaults to nil.
     ///   - waypoints: Array of ``Waypoint`` values. Defaults to nil.
     ///   - title: String describing the track.
-    ///   - trackPoints: Array of ``GPXPoint``s describing the route.
+    ///   - tracks: Array of ``GPXTrack``s describing the routes.
     ///   - keywords: Array of `String`s with keywords. Default is an empty array (no keywords).
-    public init(date: Date? = nil, waypoints: [Waypoint]? = nil, title: String, description: String? = nil, trackPoints: [GPXPoint], keywords: [String] = []) {
+    public init(date: Date? = nil, waypoints: [Waypoint]? = nil, title: String, description: String? = nil, tracks: [GPXTrack], keywords: [String] = []) {
+        let trackPoints = tracks.flatMap{$0.trackPoints}
         self.date = date
         self.waypoints = waypoints
         self.title = title
         self.description = description
-        self.trackPoints = trackPoints
+        self.tracks = tracks
         self.graph = TrackGraph(coords: trackPoints.map(\.coordinate))
         self.bounds = trackPoints.bounds()
         self.keywords = keywords
@@ -51,17 +52,22 @@ public struct GPX: Hashable, Sendable {
     ///   - date: The date stamp of the track. Defaults to nil.
     ///   - waypoints: Array of ``Waypoint`` values. Defaults to nil.
     ///   - title: String describing the track.
-    ///   - trackPoints: Array of ``GPXPoint``s describing the route.
+    ///   - tracks: Array of ``GPXTrack``s describing the routes.
     ///   - keywords: Array of `String`s with keywords. Default is an empty array (no keywords).
     ///   - elevationSmoothing: The ``ElevationSmoothing`` in meters for the grade segments. Defaults to ``ElevationSmoothing/segmentation(_:)`` with 50 meters.
-    public init(date: Date? = nil, waypoints: [Waypoint]? = nil, title: String, description: String? = nil, trackPoints: [GPXPoint], keywords: [String] = [], elevationSmoothing: ElevationSmoothing = .segmentation(50)) throws {
+    public init(date: Date? = nil, waypoints: [Waypoint]? = nil, title: String, description: String? = nil, tracks: [GPXTrack], keywords: [String] = [], elevationSmoothing: ElevationSmoothing = .segmentation(50)) throws {
+        let trackPoints = tracks.flatMap{$0.trackPoints}
         self.date = date
         self.waypoints = waypoints
         self.title = title
         self.description = description
-        self.trackPoints = trackPoints
+        self.tracks = tracks
         self.graph = try TrackGraph(points: trackPoints, elevationSmoothing: elevationSmoothing)
         self.bounds = trackPoints.bounds()
         self.keywords = keywords
+    }
+    
+    public var trackPoints : [GPXPoint] {
+        return self.tracks.flatMap{$0.trackPoints}
     }
 }

--- a/Sources/GPXKit/GPX.swift
+++ b/Sources/GPXKit/GPX.swift
@@ -15,10 +15,6 @@ public struct GPX: Hashable, Sendable {
     public var date: Date?
     /// Waypoint defined for the gpx
     public var waypoints: [Waypoint]?
-    /// Title of the gpx track
-    public var title: String
-    /// Description of the gpx track
-    public var description: String?
     /// Array of tracks
     public var tracks: [GPXTrack]
     /// `TrackGraph` containing elevation gain, overall distance and the height map of a track.
@@ -32,15 +28,12 @@ public struct GPX: Hashable, Sendable {
     /// - Parameters:
     ///   - date: The date stamp of the track. Defaults to nil.
     ///   - waypoints: Array of ``Waypoint`` values. Defaults to nil.
-    ///   - title: String describing the track.
     ///   - tracks: Array of ``GPXTrack``s describing the routes.
     ///   - keywords: Array of `String`s with keywords. Default is an empty array (no keywords).
-    public init(date: Date? = nil, waypoints: [Waypoint]? = nil, title: String, description: String? = nil, tracks: [GPXTrack], keywords: [String] = []) {
+    public init(date: Date? = nil, waypoints: [Waypoint]? = nil, tracks: [GPXTrack], keywords: [String] = []) {
         let trackPoints = tracks.flatMap{$0.trackPoints}
         self.date = date
         self.waypoints = waypoints
-        self.title = title
-        self.description = description
         self.tracks = tracks
         self.graph = TrackGraph(coords: trackPoints.map(\.coordinate))
         self.bounds = trackPoints.bounds()
@@ -51,16 +44,13 @@ public struct GPX: Hashable, Sendable {
     /// - Parameters:
     ///   - date: The date stamp of the track. Defaults to nil.
     ///   - waypoints: Array of ``Waypoint`` values. Defaults to nil.
-    ///   - title: String describing the track.
     ///   - tracks: Array of ``GPXTrack``s describing the routes.
     ///   - keywords: Array of `String`s with keywords. Default is an empty array (no keywords).
     ///   - elevationSmoothing: The ``ElevationSmoothing`` in meters for the grade segments. Defaults to ``ElevationSmoothing/segmentation(_:)`` with 50 meters.
-    public init(date: Date? = nil, waypoints: [Waypoint]? = nil, title: String, description: String? = nil, tracks: [GPXTrack], keywords: [String] = [], elevationSmoothing: ElevationSmoothing = .segmentation(50)) throws {
+    public init(date: Date? = nil, waypoints: [Waypoint]? = nil, tracks: [GPXTrack], keywords: [String] = [], elevationSmoothing: ElevationSmoothing = .segmentation(50)) throws {
         let trackPoints = tracks.flatMap{$0.trackPoints}
         self.date = date
         self.waypoints = waypoints
-        self.title = title
-        self.description = description
         self.tracks = tracks
         self.graph = try TrackGraph(points: trackPoints, elevationSmoothing: elevationSmoothing)
         self.bounds = trackPoints.bounds()

--- a/Sources/GPXKit/GPXExporter.swift
+++ b/Sources/GPXKit/GPXExporter.swift
@@ -66,9 +66,9 @@ public final class GPXExporter {
     }
 
     private var trackXML: String {
-        guard !track.trackPoints.isEmpty else { return "" }
+        guard !track.getTrackPoints().isEmpty else { return "" }
         return GPXTags.trackSegment.embed(
-            track.trackPoints.map { point in
+            track.getTrackPoints().map { point in
                 let attributes = [
                     GPXAttributes.latitude.assign("\"\(point.coordinate.latitude)\""),
                     GPXAttributes.longitude.assign("\"\(point.coordinate.longitude)\"")

--- a/Sources/GPXKit/GPXExporter.swift
+++ b/Sources/GPXKit/GPXExporter.swift
@@ -5,7 +5,7 @@ import FoundationXML
 
 /// A class for exporting a `GPXTrack` to an xml string.
 public final class GPXExporter {
-    private let track: GPXTrack
+    private let track: GPX
     private let exportDate: Bool
 
     /// Initializes a GPXExporter
@@ -14,7 +14,7 @@ public final class GPXExporter {
     ///   - shouldExportDate: Flag indicating whether it should export the timestamps in the track. Set it to false if you want to omit the values. This would decrease the exported xml's file size and protects privacy. Defaults to true.
     ///
     /// If the track cannot be exported, the resulting ``GPXExporter/xmlString`` property of the exporter is an empty GPX track xml.
-    public init(track: GPXTrack, shouldExportDate: Bool = true) {
+    public init(track: GPX, shouldExportDate: Bool = true) {
         self.track = track
         self.exportDate = shouldExportDate
     }

--- a/Sources/GPXKit/GPXExporter.swift
+++ b/Sources/GPXKit/GPXExporter.swift
@@ -3,19 +3,19 @@ import Foundation
 import FoundationXML
 #endif
 
-/// A class for exporting a `GPXTrack` to an xml string.
+/// A class for exporting a `GPX` to an xml string.
 public final class GPXExporter {
-    private let track: GPX
+    private let gpx: GPX
     private let exportDate: Bool
 
     /// Initializes a GPXExporter
     /// - Parameters:
-    ///   - track: The ``GPXTrack`` to export.
+    ///   - gpx: The ``GPX`` to export.
     ///   - shouldExportDate: Flag indicating whether it should export the timestamps in the track. Set it to false if you want to omit the values. This would decrease the exported xml's file size and protects privacy. Defaults to true.
     ///
     /// If the track cannot be exported, the resulting ``GPXExporter/xmlString`` property of the exporter is an empty GPX track xml.
     public init(track: GPX, shouldExportDate: Bool = true) {
-        self.track = track
+        self.gpx = track
         self.exportDate = shouldExportDate
     }
 
@@ -24,28 +24,24 @@ public final class GPXExporter {
         return """
         <?xml version="1.0" encoding="UTF-8"?>
         \(GPXTags.gpx.embed(attributes: headerAttributes,
-                            [
-                                GPXTags.metadata.embed([
-                                    metaDataTime,
-                                    track.keywords.isEmpty ? "" : GPXTags.keywords.embed(track.keywords.joined(separator: " "))
-                                ].joined(separator: "\n")),
-                                waypointsXML,
-                                GPXTags.track.embed([
-                                    GPXTags.name.embed(track.title),
-                                    track.description.flatMap { GPXTags.description.embed( $0) } ?? "",
-                                    trackXML
-                                ].joined(separator: "\n"))
-                            ].joined(separator: "\n")))
+            [
+                GPXTags.metadata.embed([
+                    metaDataTime,
+                    gpx.keywords.isEmpty ? "" : GPXTags.keywords.embed(gpx.keywords.joined(separator: " "))
+                ].joined(separator: "\n")),
+                waypointsXML,
+                tracksXML,
+            ].joined(separator: "\n")))
         """
     }
 
     private var metaDataTime: String {
-        guard exportDate, let date = track.date else { return "" }
+        guard exportDate, let date = gpx.date else { return "" }
         return GPXTags.time.embed(ISO8601DateFormatter.exporting.string(from: date))
     }
 
     private var waypointsXML: String {
-        guard let waypoints = track.waypoints, !waypoints.isEmpty else { return "" }
+        guard let waypoints = gpx.waypoints, !waypoints.isEmpty else { return "" }
         return waypoints.map { waypoint in
             let attributes = [
                 GPXAttributes.latitude.assign("\"\(waypoint.coordinate.latitude)\""),
@@ -65,27 +61,38 @@ public final class GPXExporter {
         }.joined(separator: "\n")
     }
 
-    private var trackXML: String {
-        guard !track.getTrackPoints().isEmpty else { return "" }
-        return GPXTags.trackSegment.embed(
-            track.getTrackPoints().map { point in
-                let attributes = [
-                    GPXAttributes.latitude.assign("\"\(point.coordinate.latitude)\""),
-                    GPXAttributes.longitude.assign("\"\(point.coordinate.longitude)\"")
-                ].joined(separator: " ")
-                let children = [GPXTags.elevation.embed(String(format:"%.2f", point.coordinate.elevation)),
-                              exportDate ? point.date.flatMap {
-                    GPXTags.time.embed(ISO8601DateFormatter.exporting.string(from: $0))
-                } : nil
-                ].compactMap { $0 }.joined(separator: "\n")
-                return GPXTags.trackPoint.embed(
-                    attributes: attributes,
-                    children
-                )
-            }.joined(separator: "\n")
-        )
-    }
+    private var tracksXML: String {
+        return gpx.tracks.map { track in
+            return GPXTags.track.embed([
+                GPXTags.name.embed(gpx.title),
+                gpx.description.flatMap { GPXTags.description.embed( $0) } ?? "",
+                
+                track.trackSegments.map { segment in
+                    return GPXTags.trackSegment.embed([
 
+                        segment.trackPoints.map { point in
+                            let attributes = [
+                                GPXAttributes.latitude.assign("\"\(point.coordinate.latitude)\""),
+                                GPXAttributes.longitude.assign("\"\(point.coordinate.longitude)\"")
+                            ].joined(separator: " ")
+                            let children = [GPXTags.elevation.embed(String(format:"%.2f", point.coordinate.elevation)),
+                                          exportDate ? point.date.flatMap {
+                                GPXTags.time.embed(ISO8601DateFormatter.exporting.string(from: $0))
+                            } : nil
+                            ].compactMap { $0 }.joined(separator: "\n")
+                            return GPXTags.trackPoint.embed(
+                                attributes: attributes,
+                                children
+                            )
+                        }.joined(separator: "\n")
+
+                    ].joined(separator: "\n"))
+                }.joined(separator: "\n")
+
+            ].joined(separator: "\n"))
+        }.joined(separator: "\n")
+    }
+    
     private var headerAttributes: String {
         return """
             creator="GPXKit" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd http://www.garmin.com/xmlschemas/GpxExtensions/v3 http://www.garmin.com/xmlschemas/GpxExtensionsv3.xsd http://www.garmin.com/xmlschemas/TrackPointExtension/v1 http://www.garmin.com/xmlschemas/TrackPointExtensionv1.xsd" version="1.1" xmlns="http://www.topografix.com/GPX/1/1" xmlns:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1" xmlns:gpxx="http://www.garmin.com/xmlschemas/GpxExtensions/v3"

--- a/Sources/GPXKit/GPXExporter.swift
+++ b/Sources/GPXKit/GPXExporter.swift
@@ -63,11 +63,15 @@ public final class GPXExporter {
 
     private var tracksXML: String {
         return gpx.tracks.map { track in
-            return GPXTags.track.embed([
-                GPXTags.name.embed(gpx.title),
-                gpx.description.flatMap { GPXTags.description.embed( $0) } ?? "",
-                
-                track.trackSegments.map { segment in
+            var metadata = [String]()
+            if let name = track.name, !name.isEmpty {
+                metadata.append(GPXTags.name.embed(name))
+            }
+            if let description = track.description, !description.isEmpty {
+                metadata.append(GPXTags.description.embed(description))
+            }
+            return GPXTags.track.embed(( metadata +
+                [track.trackSegments.map { segment in
                     return GPXTags.trackSegment.embed([
 
                         segment.trackPoints.map { point in
@@ -88,8 +92,7 @@ public final class GPXExporter {
 
                     ].joined(separator: "\n"))
                 }.joined(separator: "\n")
-
-            ].joined(separator: "\n"))
+            ]).joined(separator: "\n"))
         }.joined(separator: "\n")
     }
     

--- a/Sources/GPXKit/GPXFileParser.swift
+++ b/Sources/GPXKit/GPXFileParser.swift
@@ -120,10 +120,10 @@ public final class GPXFileParser {
         return node.childFor(.time)?.date
     }
 
-    private func parseSegment(_ segmentNodes: [XMLNode]) -> [TrackPoint] {
+    private func parseSegment(_ segmentNodes: [XMLNode]) -> [GPXPoint] {
         guard !segmentNodes.isEmpty else { return [] }
         
-        var trackPoints = segmentNodes.map{$0.childrenOfType(.trackPoint).compactMap(TrackPoint.init)}.flatMap { $0 }
+        var trackPoints = segmentNodes.map{$0.childrenOfType(.trackPoint).compactMap(GPXPoint.init)}.flatMap { $0 }
         checkForInvalidElevationAtStartAndEnd(trackPoints: &trackPoints)
         return correctElevationGaps(trackPoints: trackPoints)
             .map {
@@ -143,11 +143,11 @@ public final class GPXFileParser {
             }
     }
 
-    private func parseRoute(_ routeNode: XMLNode?) -> [TrackPoint] {
+    private func parseRoute(_ routeNode: XMLNode?) -> [GPXPoint] {
         guard let node = routeNode else {
             return []
         }
-        var trackPoints = node.childrenOfType(.routePoint).compactMap(TrackPoint.init)
+        var trackPoints = node.childrenOfType(.routePoint).compactMap(GPXPoint.init)
         checkForInvalidElevationAtStartAndEnd(trackPoints: &trackPoints)
         return correctElevationGaps(trackPoints: trackPoints)
             .map {
@@ -167,7 +167,7 @@ public final class GPXFileParser {
             }
     }
 
-    private func checkForInvalidElevationAtStartAndEnd(trackPoints: inout [TrackPoint]) {
+    private func checkForInvalidElevationAtStartAndEnd(trackPoints: inout [GPXPoint]) {
         if
             trackPoints.first?.coordinate.elevation == .greatestFiniteMagnitude,
             let firstValidElevation = trackPoints.first(where: { $0.coordinate.elevation != .greatestFiniteMagnitude })?
@@ -184,7 +184,7 @@ public final class GPXFileParser {
         }
     }
 
-    private func correctElevationGaps(trackPoints: [TrackPoint]) -> [TrackPoint] {
+    private func correctElevationGaps(trackPoints: [GPXPoint]) -> [GPXPoint] {
         struct Grade {
             var start: Coordinate
             var grade: Double
@@ -204,9 +204,9 @@ public final class GPXFileParser {
             let elevationDelta = end.coordinate.elevation - start.coordinate.elevation
             return Grade(start: start.coordinate, grade: elevationDelta / dist)
         }
-        var corrected: [[TrackPoint]] = zip(chunks.filter(\.0), grades).map { chunk, grade in
+        var corrected: [[GPXPoint]] = zip(chunks.filter(\.0), grades).map { chunk, grade in
             return chunk.1.map {
-                TrackPoint(
+                GPXPoint(
                     coordinate: .init(
                         latitude: $0.latitude,
                         longitude: $0.longitude,
@@ -221,7 +221,7 @@ public final class GPXFileParser {
             }
         }
 
-        var result: [TrackPoint] = []
+        var result: [GPXPoint] = []
         for chunk in chunks {
             if !corrected.isEmpty, chunk.0 {
                 result.append(contentsOf: corrected.removeFirst())
@@ -254,7 +254,7 @@ internal extension Waypoint {
     }
 }
 
-internal extension TrackPoint {
+internal extension GPXPoint {
     init?(trackNode: XMLNode) {
         guard
             let lat = trackNode.latitude,

--- a/Sources/GPXKit/GPXFileParser.swift
+++ b/Sources/GPXKit/GPXFileParser.swift
@@ -59,7 +59,7 @@ public final class GPXFileParser {
     /// Parses the GPX xml.
     /// - Returns: A ``Result`` of the ``GPXTrack`` in the success or an ``GPXParserError`` in the failure case.
     /// - Parameter elevationSmoothing: The ``ElevationSmoothing`` in meters for the grade segments. Defaults to ``ElevationSmoothing/none``.
-    public func parse(elevationSmoothing: ElevationSmoothing = .none) -> Result<GPXTrack, GPXParserError> {
+    public func parse(elevationSmoothing: ElevationSmoothing = .none) -> Result<GPX, GPXParserError> {
         let parser = BasicXMLParser(xml: xml)
         switch parser.parse() {
         case let .success(root):
@@ -79,9 +79,9 @@ public final class GPXFileParser {
         }
     }
 
-    private func parseRoot(node: XMLNode, elevationSmoothing: ElevationSmoothing) throws -> GPXTrack {
+    private func parseRoot(node: XMLNode, elevationSmoothing: ElevationSmoothing) throws -> GPX {
         guard let trackNode = node.childFor(.track) ?? node.childFor(.route) else {
-            return try GPXTrack(
+            return try GPX(
                 date: node.childFor(.metadata)?.childFor(.time)?.date,
                 waypoints: parseWaypoints(node.childrenOfType(.waypoint)),
                 title: "",
@@ -93,7 +93,7 @@ public final class GPXFileParser {
         }
         let title = trackNode.childFor(.name)?.content ?? ""
         let isRoute = trackNode.name == GPXTags.route.rawValue
-        return try GPXTrack(
+        return try GPX(
             date: node.childFor(.metadata)?.childFor(.time)?.date,
             waypoints: parseWaypoints(node.childrenOfType(.waypoint)),
             title: title,

--- a/Sources/GPXKit/GPXFileParser.swift
+++ b/Sources/GPXKit/GPXFileParser.swift
@@ -136,10 +136,14 @@ public final class GPXFileParser {
 
     private func parseTrack(_ trackNode: XMLNode?) -> GPXTrack? {
         guard let node = trackNode else {return nil}
+
+        let name = node.childFor(.name)?.content
+        let description = node.childFor(.description)?.content
         let segmentsNodes = node.childrenOfType(.trackSegment)
-        if segmentsNodes.isEmpty {return nil}
+
+        if segmentsNodes.isEmpty && name == nil {return nil}
+
         var segments : [GPXSegment] = []
-        
         for segmentNode in segmentsNodes {
             var trackPoints = segmentNode.childrenOfType(.trackPoint).compactMap(GPXPoint.init)
             checkForInvalidElevationAtStartAndEnd(trackPoints: &trackPoints)
@@ -162,7 +166,7 @@ public final class GPXFileParser {
             segments.append(GPXSegment(trackPoints: trackPoints))
         }
         
-        return GPXTrack(trackSegments: segments)
+        return GPXTrack(name: name, description: description, trackSegments: segments)
     }
 
     private func parseRoute(_ routeNode: XMLNode?) -> GPXTrack? {

--- a/Sources/GPXKit/GPXFileParser.swift
+++ b/Sources/GPXKit/GPXFileParser.swift
@@ -86,8 +86,6 @@ public final class GPXFileParser {
             return try GPX(
                 date: node.childFor(.metadata)?.childFor(.time)?.date,
                 waypoints: parseWaypoints(node.childrenOfType(.waypoint)),
-                title: "",
-                description: nil,
                 tracks: [],
                 keywords: parseKeywords(node: node),
                 elevationSmoothing: elevationSmoothing
@@ -105,12 +103,9 @@ public final class GPXFileParser {
                 }
             }
         }
-        let title = trackNodes[0].childFor(.name)?.content ?? ""
         return try GPX(
             date: node.childFor(.metadata)?.childFor(.time)?.date,
             waypoints: parseWaypoints(node.childrenOfType(.waypoint)),
-            title: title,
-            description: trackNodes[0].childFor(.description)?.content,
             tracks: tracks,
             keywords: parseKeywords(node: node),
             elevationSmoothing: elevationSmoothing

--- a/Sources/GPXKit/GPXPoint.swift
+++ b/Sources/GPXKit/GPXPoint.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A value describing a single data point in a `GPXTrack`. A `TrackPoint` has the latitude, longitude and elevation data along with meta data such as a timestamp or power values.
-public struct TrackPoint: Hashable, Sendable {
+public struct GPXPoint: Hashable, Sendable {
     /// The ``Coordinate`` (latitude, longitude and elevation in meters)
     public var coordinate: Coordinate
     /// Optional date for a given point. This is the date stamp from a gpx file, recorded from a bicycle computer or running watch.
@@ -34,7 +34,7 @@ public struct TrackPoint: Hashable, Sendable {
     }
 }
 
-extension TrackPoint: GeoCoordinate {
+extension GPXPoint: GeoCoordinate {
     public var latitude: Double { coordinate.latitude }
     public var longitude: Double { coordinate.longitude }
 }

--- a/Sources/GPXKit/GPXSegment.swift
+++ b/Sources/GPXKit/GPXSegment.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// A value describing a segment of geo locations
+public struct GPXSegment: Hashable, Sendable {
+    /// Array of latitude/longitude/elevation stream values
+    public var trackPoints: [GPXPoint]
+    
+    /// Initializer
+    /// You don't need to construct this value by yourself, as it is done by GXPKits track parsing logic.
+    /// - Parameters:
+    ///   - trackPoints: Array of ``GPXPoint``s describing the route.
+    public init(trackPoints: [GPXPoint]) {
+        self.trackPoints = trackPoints
+    }
+}

--- a/Sources/GPXKit/GPXTrack.swift
+++ b/Sources/GPXKit/GPXTrack.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// A value describing a track of geo locations
+public struct GPXTrack: Hashable, Sendable {
+    /// Array of track segments
+    public var trackSegments: [GPXSegment]
+    
+    
+    /// Initializer
+    /// You don't need to construct this value by yourself, as it is done by GXPKits track parsing logic.
+    /// - Parameters:
+    ///   - trackSegments: Array of ``GPXSegment``s describing the route.
+    public init(trackSegments: [GPXSegment]) {
+        self.trackSegments = trackSegments
+    }
+    
+    public var trackPoints : [GPXPoint] {
+        return self.trackSegments.flatMap{$0.trackPoints}
+    }
+}

--- a/Sources/GPXKit/GPXTrack.swift
+++ b/Sources/GPXKit/GPXTrack.swift
@@ -2,6 +2,10 @@ import Foundation
 
 /// A value describing a track of geo locations
 public struct GPXTrack: Hashable, Sendable {
+    /// Name of the gpx track
+    public var name: String?
+    /// Description of the gpx track
+    public var description: String?
     /// Array of track segments
     public var trackSegments: [GPXSegment]
     
@@ -9,8 +13,12 @@ public struct GPXTrack: Hashable, Sendable {
     /// Initializer
     /// You don't need to construct this value by yourself, as it is done by GXPKits track parsing logic.
     /// - Parameters:
+    ///   - name: String title of the track.
+    ///   - description: String description of the track
     ///   - trackSegments: Array of ``GPXSegment``s describing the route.
-    public init(trackSegments: [GPXSegment]) {
+    public init(name: String? = nil, description: String? = nil, trackSegments: [GPXSegment] = []) {
+        self.name = name
+        self.description = description
         self.trackSegments = trackSegments
     }
     

--- a/Sources/GPXKit/TrackGraph.swift
+++ b/Sources/GPXKit/TrackGraph.swift
@@ -32,7 +32,7 @@ public struct TrackGraph: Hashable, Sendable {
     /// - Parameters:
     ///   - points: Array of `TrackPoint` values.
     ///   - gradeSegmentLength: The length of the grade segments in meters. Defaults to 25 meters. Adjacent segments with the same grade will be joined together.
-    public init(points: [TrackPoint], elevationSmoothing: ElevationSmoothing = .segmentation(50)) throws {
+    public init(points: [GPXPoint], elevationSmoothing: ElevationSmoothing = .segmentation(50)) throws {
         try self.init(coords: points.map { $0.coordinate }, elevationSmoothing: elevationSmoothing)
     }
 

--- a/Tests/GPXKitTests/CombineExtensionTests.swift
+++ b/Tests/GPXKitTests/CombineExtensionTests.swift
@@ -20,8 +20,8 @@ final class CombineExtensionTests: XCTestCase {
                     XCTFail(error.localizedDescription)
                 }
                 expectation.fulfill()
-            } receiveValue: { track in
-                self.assertTracksAreEqual(testTrack, track)
+            } receiveValue: { gpx in
+                self.assertTracksAreEqual(testTrack, gpx)
             }
 
         wait(for: [expectation], timeout: 10)
@@ -39,8 +39,8 @@ final class CombineExtensionTests: XCTestCase {
                     XCTFail(error.localizedDescription)
                 }
                 expectation.fulfill()
-            } receiveValue: { track in
-                self.assertTracksAreEqual(testTrack, track)
+            } receiveValue: { gpx in
+                self.assertTracksAreEqual(testTrack, gpx)
             }
 
         wait(for: [expectation], timeout: 10)

--- a/Tests/GPXKitTests/GPXExporterTests.swift
+++ b/Tests/GPXKitTests/GPXExporterTests.swift
@@ -42,7 +42,7 @@ final class GPXExporterTests: XCTestCase {
 
     func testExportingAnEmptyTrackWithDateAndTitleResultsInAnEmptyGPXFile() {
         let date = Date()
-        let gpx: GPX = GPX(date: date, title: "Track title", description: "Track description", tracks: [GPXTrack(name: "Track title", description: "Track description", trackSegments: [])])
+        let gpx: GPX = GPX(date: date, tracks: [GPXTrack(name: "Track title", description: "Track description", trackSegments: [])])
         sut = GPXExporter(track: gpx)
 
         let expectedContent: GPXKit.XMLNode = XMLNode(
@@ -65,7 +65,7 @@ final class GPXExporterTests: XCTestCase {
 
     func testItWillNotExportANilDescription() {
         let date = Date()
-        let gpx: GPX = GPX(date: date, title: "Track title", description: nil, tracks: [GPXTrack(name: "Track title", trackSegments: [])])
+        let gpx: GPX = GPX(date: date, tracks: [GPXTrack(name: "Track title", trackSegments: [])])
         sut = GPXExporter(track: gpx)
 
         let expectedContent: GPXKit.XMLNode = XMLNode(
@@ -86,7 +86,7 @@ final class GPXExporterTests: XCTestCase {
     }
 
     func testExportingAnEmptyTrackWithoutDateResultsInAnEmptyGPXFileWithoutTitleAndDate() {
-        let gpx: GPX = GPX(date: nil, title: "Track title", description: "Description", tracks: [GPXTrack(name: "Track title", description: "Description", trackSegments: [])], keywords: ["one", "two"])
+        let gpx: GPX = GPX(date: nil, tracks: [GPXTrack(name: "Track title", description: "Description", trackSegments: [])], keywords: ["one", "two"])
         sut = GPXExporter(track: gpx)
 
         let expectedContent: GPXKit.XMLNode = XMLNode(
@@ -111,8 +111,6 @@ final class GPXExporterTests: XCTestCase {
         let date = Date()
         let gpx: GPX = GPX(
                 date: date,
-                title: "Track title",
-                description: "Non empty track",
                 tracks: [GPXTrack(name: "Track title", description: "Non empty track", trackSegments: [GPXSegment(trackPoints: givenTrackPoints(10))])],
                 keywords: ["keyword1", "keyword2", "keyword3"])
         sut = GPXExporter(track: gpx)
@@ -156,8 +154,6 @@ final class GPXExporterTests: XCTestCase {
         let date = Date()
         let gpx: GPX = GPX(
                 date: date,
-                title: "Track title",
-                description: "Non empty track",
                 tracks: [
                     GPXTrack(name: "Track title A", description: "Non empty track A", trackSegments: [
                         GPXSegment(trackPoints: givenTrackPoints(3)),
@@ -212,7 +208,6 @@ final class GPXExporterTests: XCTestCase {
 
     func testItWillNotExportTheDatesFromTrack() {
         let gpx = GPX(date: Date(),
-                title: "test track",
                       tracks: [GPXTrack(name: "Track title", trackSegments: [GPXSegment(trackPoints: [
                     GPXPoint(coordinate: .random, date: Date()),
                     GPXPoint(coordinate: .random, date: Date()),
@@ -241,7 +236,7 @@ final class GPXExporterTests: XCTestCase {
     }
 
     func testItWillNotExportNilWaypoints() {
-        let gpx: GPX = GPX(date: Date(), waypoints: nil, title: "Track title", tracks: [GPXTrack(name: "Track title", trackSegments: [])])
+        let gpx: GPX = GPX(date: Date(), waypoints: nil, tracks: [GPXTrack(name: "Track title", trackSegments: [])])
         sut = GPXExporter(track: gpx, shouldExportDate: false)
         let expectedContent: GPXKit.XMLNode = XMLNode(
             name: GPXTags.gpx.rawValue,
@@ -263,7 +258,7 @@ final class GPXExporterTests: XCTestCase {
             Waypoint(coordinate: .dehner, name: "Dehner", comment: "Dehner comment", description: "Dehner description"),
             Waypoint(coordinate: .kreisel, name: "Kreisel", comment: "Kreisel comment", description: "Kreisel description")
         ]
-        let gpx: GPX = GPX(date: Date(), waypoints: waypoints, title: "Track title", tracks: [GPXTrack(name: "Track title", trackSegments: [])])
+        let gpx: GPX = GPX(date: Date(), waypoints: waypoints, tracks: [GPXTrack(name: "Track title", trackSegments: [])])
         sut = GPXExporter(track: gpx, shouldExportDate: false)
         let expectedContent: GPXKit.XMLNode = XMLNode(
             name: GPXTags.gpx.rawValue,

--- a/Tests/GPXKitTests/GPXExporterTests.swift
+++ b/Tests/GPXKitTests/GPXExporterTests.swift
@@ -42,7 +42,7 @@ final class GPXExporterTests: XCTestCase {
 
     func testExportingAnEmptyTrackWithDateAndTitleResultsInAnEmptyGPXFile() {
         let date = Date()
-        let track: GPXTrack = GPXTrack(date: date, title: "Track title", description: "Track description", trackPoints: [])
+        let track: GPX = GPX(date: date, title: "Track title", description: "Track description", trackPoints: [])
         sut = GPXExporter(track: track)
 
         let expectedContent: GPXKit.XMLNode = XMLNode(
@@ -65,7 +65,7 @@ final class GPXExporterTests: XCTestCase {
 
     func testItWillNotExportANilDescription() {
         let date = Date()
-        let track: GPXTrack = GPXTrack(date: date, title: "Track title", description: nil, trackPoints: [])
+        let track: GPX = GPX(date: date, title: "Track title", description: nil, trackPoints: [])
         sut = GPXExporter(track: track)
 
         let expectedContent: GPXKit.XMLNode = XMLNode(
@@ -86,7 +86,7 @@ final class GPXExporterTests: XCTestCase {
     }
 
     func testExportingAnEmptyTrackWithoutDateResultsInAnEmptyGPXFileWithoutTitleAndDate() {
-        let track: GPXTrack = GPXTrack(date: nil, title: "Track title", description: "Description", trackPoints: [], keywords: ["one", "two"])
+        let track: GPX = GPX(date: nil, title: "Track title", description: "Description", trackPoints: [], keywords: ["one", "two"])
         sut = GPXExporter(track: track)
 
         let expectedContent: GPXKit.XMLNode = XMLNode(
@@ -109,7 +109,7 @@ final class GPXExporterTests: XCTestCase {
 
     func testExportingANonEmptyTrackWithDates() {
         let date = Date()
-        let track: GPXTrack = GPXTrack(
+        let track: GPX = GPX(
                 date: date,
                 title: "Track title",
                 description: "Non empty track",
@@ -153,7 +153,7 @@ final class GPXExporterTests: XCTestCase {
     }
 
     func testItWillNotExportTheDatesFromTrack() {
-        let track = GPXTrack(date: Date(),
+        let track = GPX(date: Date(),
                 title: "test track",
                 trackPoints: [
                     TrackPoint(coordinate: .random, date: Date()),
@@ -182,7 +182,7 @@ final class GPXExporterTests: XCTestCase {
     }
 
     func testItWillNotExportNilWaypoints() {
-        let track: GPXTrack = GPXTrack(date: Date(), waypoints: nil, title: "Track title", trackPoints: [])
+        let track: GPX = GPX(date: Date(), waypoints: nil, title: "Track title", trackPoints: [])
         sut = GPXExporter(track: track, shouldExportDate: false)
         let expectedContent: GPXKit.XMLNode = XMLNode(
             name: GPXTags.gpx.rawValue,
@@ -204,7 +204,7 @@ final class GPXExporterTests: XCTestCase {
             Waypoint(coordinate: .dehner, name: "Dehner", comment: "Dehner comment", description: "Dehner description"),
             Waypoint(coordinate: .kreisel, name: "Kreisel", comment: "Kreisel comment", description: "Kreisel description")
         ]
-        let track: GPXTrack = GPXTrack(date: Date(), waypoints: waypoints, title: "Track title", trackPoints: [])
+        let track: GPX = GPX(date: Date(), waypoints: waypoints, title: "Track title", trackPoints: [])
         sut = GPXExporter(track: track, shouldExportDate: false)
         let expectedContent: GPXKit.XMLNode = XMLNode(
             name: GPXTags.gpx.rawValue,

--- a/Tests/GPXKitTests/GPXExporterTests.swift
+++ b/Tests/GPXKitTests/GPXExporterTests.swift
@@ -156,10 +156,10 @@ final class GPXExporterTests: XCTestCase {
         let track = GPX(date: Date(),
                 title: "test track",
                 trackPoints: [
-                    TrackPoint(coordinate: .random, date: Date()),
-                    TrackPoint(coordinate: .random, date: Date()),
-                    TrackPoint(coordinate: .random, date: Date()),
-                    TrackPoint(coordinate: .random, date: Date()),
+                    GPXPoint(coordinate: .random, date: Date()),
+                    GPXPoint(coordinate: .random, date: Date()),
+                    GPXPoint(coordinate: .random, date: Date()),
+                    GPXPoint(coordinate: .random, date: Date()),
                 ])
         sut = GPXExporter(track: track, shouldExportDate: false)
         let expectedContent: GPXKit.XMLNode = XMLNode(

--- a/Tests/GPXKitTests/GPXExporterTests.swift
+++ b/Tests/GPXKitTests/GPXExporterTests.swift
@@ -42,7 +42,7 @@ final class GPXExporterTests: XCTestCase {
 
     func testExportingAnEmptyTrackWithDateAndTitleResultsInAnEmptyGPXFile() {
         let date = Date()
-        let gpx: GPX = GPX(date: date, title: "Track title", description: "Track description", tracks: [GPXTrack(trackSegments: [])])
+        let gpx: GPX = GPX(date: date, title: "Track title", description: "Track description", tracks: [GPXTrack(name: "Track title", description: "Track description", trackSegments: [])])
         sut = GPXExporter(track: gpx)
 
         let expectedContent: GPXKit.XMLNode = XMLNode(
@@ -53,7 +53,7 @@ final class GPXExporterTests: XCTestCase {
                         XMLNode(name: GPXTags.time.rawValue, content: expectedString(for: date))
                     ]),
                     XMLNode(name: GPXTags.track.rawValue, children: [
-                        XMLNode(name: GPXTags.name.rawValue, content: gpx.title),
+                        XMLNode(name: GPXTags.name.rawValue, content: "Track title"),
                         XMLNode(name: GPXTags.description.rawValue, content: "Track description")
                     ])
                 ])
@@ -65,7 +65,7 @@ final class GPXExporterTests: XCTestCase {
 
     func testItWillNotExportANilDescription() {
         let date = Date()
-        let gpx: GPX = GPX(date: date, title: "Track title", description: nil, tracks: [GPXTrack(trackSegments: [])])
+        let gpx: GPX = GPX(date: date, title: "Track title", description: nil, tracks: [GPXTrack(name: "Track title", trackSegments: [])])
         sut = GPXExporter(track: gpx)
 
         let expectedContent: GPXKit.XMLNode = XMLNode(
@@ -76,7 +76,7 @@ final class GPXExporterTests: XCTestCase {
                         XMLNode(name: GPXTags.time.rawValue, content: expectedString(for: date))
                     ]),
                     XMLNode(name: GPXTags.track.rawValue, children: [
-                        XMLNode(name: GPXTags.name.rawValue, content: gpx.title)
+                        XMLNode(name: GPXTags.name.rawValue, content: "Track title")
                     ])
                 ])
 
@@ -86,7 +86,7 @@ final class GPXExporterTests: XCTestCase {
     }
 
     func testExportingAnEmptyTrackWithoutDateResultsInAnEmptyGPXFileWithoutTitleAndDate() {
-        let gpx: GPX = GPX(date: nil, title: "Track title", description: "Description", tracks: [GPXTrack(trackSegments: [])], keywords: ["one", "two"])
+        let gpx: GPX = GPX(date: nil, title: "Track title", description: "Description", tracks: [GPXTrack(name: "Track title", description: "Description", trackSegments: [])], keywords: ["one", "two"])
         sut = GPXExporter(track: gpx)
 
         let expectedContent: GPXKit.XMLNode = XMLNode(
@@ -97,7 +97,7 @@ final class GPXExporterTests: XCTestCase {
                         XMLNode(name: GPXTags.keywords.rawValue, content: "one two")
                     ]),
                     XMLNode(name: GPXTags.track.rawValue, children: [
-                        XMLNode(name: GPXTags.name.rawValue, content: gpx.title),
+                        XMLNode(name: GPXTags.name.rawValue, content: "Track title"),
                         XMLNode(name: GPXTags.description.rawValue, content: "Description")
                     ])
                 ])
@@ -113,7 +113,7 @@ final class GPXExporterTests: XCTestCase {
                 date: date,
                 title: "Track title",
                 description: "Non empty track",
-                tracks: [GPXTrack(trackSegments: [GPXSegment(trackPoints: givenTrackPoints(10))])],
+                tracks: [GPXTrack(name: "Track title", description: "Non empty track", trackSegments: [GPXSegment(trackPoints: givenTrackPoints(10))])],
                 keywords: ["keyword1", "keyword2", "keyword3"])
         sut = GPXExporter(track: gpx)
 
@@ -128,7 +128,7 @@ final class GPXExporterTests: XCTestCase {
                         XMLNode(name: GPXTags.keywords.rawValue, content: "keyword1 keyword2 keyword3")
                     ]),
                     XMLNode(name: GPXTags.track.rawValue, children: [
-                        XMLNode(name: GPXTags.name.rawValue, content: gpx.title),
+                        XMLNode(name: GPXTags.name.rawValue, content: "Track title"),
                         XMLNode(name: GPXTags.description.rawValue, content: "Non empty track"),
                         XMLNode(name: GPXTags.trackSegment.rawValue,
                                 children: gpx.trackPoints.map {
@@ -159,11 +159,11 @@ final class GPXExporterTests: XCTestCase {
                 title: "Track title",
                 description: "Non empty track",
                 tracks: [
-                    GPXTrack(trackSegments: [
+                    GPXTrack(name: "Track title A", description: "Non empty track A", trackSegments: [
                         GPXSegment(trackPoints: givenTrackPoints(3)),
                         GPXSegment(trackPoints: givenTrackPoints(3))
                     ]),
-                    GPXTrack(trackSegments: [
+                    GPXTrack(name: "Track title B", description: "Non empty track B", trackSegments: [
                         GPXSegment(trackPoints: givenTrackPoints(3)),
                         GPXSegment(trackPoints: givenTrackPoints(3))
                     ])
@@ -182,8 +182,8 @@ final class GPXExporterTests: XCTestCase {
                         XMLNode(name: GPXTags.keywords.rawValue, content: "keyword1 keyword2 keyword3")
                     ]),
                     XMLNode(name: GPXTags.track.rawValue, children: [
-                        XMLNode(name: GPXTags.name.rawValue, content: gpx.title),
-                        XMLNode(name: GPXTags.description.rawValue, content: "Non empty track"),
+                        XMLNode(name: GPXTags.name.rawValue, content: "Track title A"),
+                        XMLNode(name: GPXTags.description.rawValue, content: "Non empty track A"),
                         XMLNode(name: GPXTags.trackSegment.rawValue,
                                 children: gpx.tracks[0].trackSegments[0].trackPoints.map {
                                     $0.expectedXMLNode(withDate: true)
@@ -194,8 +194,8 @@ final class GPXExporterTests: XCTestCase {
                                 })
                     ]),
                     XMLNode(name: GPXTags.track.rawValue, children: [
-                        XMLNode(name: GPXTags.name.rawValue, content: gpx.title),
-                        XMLNode(name: GPXTags.description.rawValue, content: "Non empty track"),
+                        XMLNode(name: GPXTags.name.rawValue, content: "Track title B"),
+                        XMLNode(name: GPXTags.description.rawValue, content: "Non empty track B"),
                         XMLNode(name: GPXTags.trackSegment.rawValue,
                                 children: gpx.tracks[1].trackSegments[0].trackPoints.map {
                                     $0.expectedXMLNode(withDate: true)
@@ -213,7 +213,7 @@ final class GPXExporterTests: XCTestCase {
     func testItWillNotExportTheDatesFromTrack() {
         let gpx = GPX(date: Date(),
                 title: "test track",
-                tracks: [GPXTrack(trackSegments: [GPXSegment(trackPoints: [
+                      tracks: [GPXTrack(name: "Track title", trackSegments: [GPXSegment(trackPoints: [
                     GPXPoint(coordinate: .random, date: Date()),
                     GPXPoint(coordinate: .random, date: Date()),
                     GPXPoint(coordinate: .random, date: Date()),
@@ -227,7 +227,7 @@ final class GPXExporterTests: XCTestCase {
                 children: [
                     XMLNode(name: GPXTags.metadata.rawValue),
                     XMLNode(name: GPXTags.track.rawValue, children: [
-                        XMLNode(name: GPXTags.name.rawValue, content: gpx.title),
+                        XMLNode(name: GPXTags.name.rawValue, content: "Track title"),
                         XMLNode(name: GPXTags.trackSegment.rawValue,
                                 children: gpx.trackPoints.map {
                                     $0.expectedXMLNode(withDate: false)
@@ -241,7 +241,7 @@ final class GPXExporterTests: XCTestCase {
     }
 
     func testItWillNotExportNilWaypoints() {
-        let gpx: GPX = GPX(date: Date(), waypoints: nil, title: "Track title", tracks: [GPXTrack(trackSegments: [])])
+        let gpx: GPX = GPX(date: Date(), waypoints: nil, title: "Track title", tracks: [GPXTrack(name: "Track title", trackSegments: [])])
         sut = GPXExporter(track: gpx, shouldExportDate: false)
         let expectedContent: GPXKit.XMLNode = XMLNode(
             name: GPXTags.gpx.rawValue,
@@ -249,7 +249,7 @@ final class GPXExporterTests: XCTestCase {
             children: [
                 XMLNode(name: GPXTags.metadata.rawValue),
                 XMLNode(name: GPXTags.track.rawValue, children: [
-                    XMLNode(name: GPXTags.name.rawValue, content: gpx.title),
+                    XMLNode(name: GPXTags.name.rawValue, content: "Track title"),
                 ])
             ])
 
@@ -263,7 +263,7 @@ final class GPXExporterTests: XCTestCase {
             Waypoint(coordinate: .dehner, name: "Dehner", comment: "Dehner comment", description: "Dehner description"),
             Waypoint(coordinate: .kreisel, name: "Kreisel", comment: "Kreisel comment", description: "Kreisel description")
         ]
-        let gpx: GPX = GPX(date: Date(), waypoints: waypoints, title: "Track title", tracks: [GPXTrack(trackSegments: [])])
+        let gpx: GPX = GPX(date: Date(), waypoints: waypoints, title: "Track title", tracks: [GPXTrack(name: "Track title", trackSegments: [])])
         sut = GPXExporter(track: gpx, shouldExportDate: false)
         let expectedContent: GPXKit.XMLNode = XMLNode(
             name: GPXTags.gpx.rawValue,
@@ -287,7 +287,7 @@ final class GPXExporterTests: XCTestCase {
                     XMLNode(name: GPXTags.description.rawValue, content: "Kreisel description"),
                 ]),
                 XMLNode(name: GPXTags.track.rawValue, children: [
-                    XMLNode(name: GPXTags.name.rawValue, content: gpx.title),
+                    XMLNode(name: GPXTags.name.rawValue, content: "Track title"),
                 ])
             ])
 

--- a/Tests/GPXKitTests/GPXExporterTests.swift
+++ b/Tests/GPXKitTests/GPXExporterTests.swift
@@ -42,7 +42,7 @@ final class GPXExporterTests: XCTestCase {
 
     func testExportingAnEmptyTrackWithDateAndTitleResultsInAnEmptyGPXFile() {
         let date = Date()
-        let gpx: GPX = GPX(date: date, title: "Track title", description: "Track description", tracks: [])
+        let gpx: GPX = GPX(date: date, title: "Track title", description: "Track description", tracks: [GPXTrack(trackSegments: [])])
         sut = GPXExporter(track: gpx)
 
         let expectedContent: GPXKit.XMLNode = XMLNode(
@@ -65,7 +65,7 @@ final class GPXExporterTests: XCTestCase {
 
     func testItWillNotExportANilDescription() {
         let date = Date()
-        let gpx: GPX = GPX(date: date, title: "Track title", description: nil, tracks: [])
+        let gpx: GPX = GPX(date: date, title: "Track title", description: nil, tracks: [GPXTrack(trackSegments: [])])
         sut = GPXExporter(track: gpx)
 
         let expectedContent: GPXKit.XMLNode = XMLNode(
@@ -86,7 +86,7 @@ final class GPXExporterTests: XCTestCase {
     }
 
     func testExportingAnEmptyTrackWithoutDateResultsInAnEmptyGPXFileWithoutTitleAndDate() {
-        let gpx: GPX = GPX(date: nil, title: "Track title", description: "Description", tracks: [], keywords: ["one", "two"])
+        let gpx: GPX = GPX(date: nil, title: "Track title", description: "Description", tracks: [GPXTrack(trackSegments: [])], keywords: ["one", "two"])
         sut = GPXExporter(track: gpx)
 
         let expectedContent: GPXKit.XMLNode = XMLNode(
@@ -241,7 +241,7 @@ final class GPXExporterTests: XCTestCase {
     }
 
     func testItWillNotExportNilWaypoints() {
-        let gpx: GPX = GPX(date: Date(), waypoints: nil, title: "Track title", tracks: [])
+        let gpx: GPX = GPX(date: Date(), waypoints: nil, title: "Track title", tracks: [GPXTrack(trackSegments: [])])
         sut = GPXExporter(track: gpx, shouldExportDate: false)
         let expectedContent: GPXKit.XMLNode = XMLNode(
             name: GPXTags.gpx.rawValue,
@@ -263,7 +263,7 @@ final class GPXExporterTests: XCTestCase {
             Waypoint(coordinate: .dehner, name: "Dehner", comment: "Dehner comment", description: "Dehner description"),
             Waypoint(coordinate: .kreisel, name: "Kreisel", comment: "Kreisel comment", description: "Kreisel description")
         ]
-        let gpx: GPX = GPX(date: Date(), waypoints: waypoints, title: "Track title", tracks: [])
+        let gpx: GPX = GPX(date: Date(), waypoints: waypoints, title: "Track title", tracks: [GPXTrack(trackSegments: [])])
         sut = GPXExporter(track: gpx, shouldExportDate: false)
         let expectedContent: GPXKit.XMLNode = XMLNode(
             name: GPXTags.gpx.rawValue,

--- a/Tests/GPXKitTests/GPXExporterTests.swift
+++ b/Tests/GPXKitTests/GPXExporterTests.swift
@@ -151,6 +151,64 @@ final class GPXExporterTests: XCTestCase {
             XCTFail(error.localizedDescription)
         }
     }
+    
+    func testExportingAMultipleTracksWithMultipleSegments() {
+        let date = Date()
+        let gpx: GPX = GPX(
+                date: date,
+                title: "Track title",
+                description: "Non empty track",
+                tracks: [
+                    GPXTrack(trackSegments: [
+                        GPXSegment(trackPoints: givenTrackPoints(3)),
+                        GPXSegment(trackPoints: givenTrackPoints(3))
+                    ]),
+                    GPXTrack(trackSegments: [
+                        GPXSegment(trackPoints: givenTrackPoints(3)),
+                        GPXSegment(trackPoints: givenTrackPoints(3))
+                    ])
+                ],
+                keywords: ["keyword1", "keyword2", "keyword3"])
+        sut = GPXExporter(track: gpx)
+
+        parseResult(sut.xmlString)
+
+        let expectedContent: GPXKit.XMLNode = XMLNode(
+                name: GPXTags.gpx.rawValue,
+                attributes: expectedHeaderAttributes,
+                children: [
+                    XMLNode(name: GPXTags.metadata.rawValue, children: [
+                        XMLNode(name: GPXTags.time.rawValue, content: expectedString(for: date)),
+                        XMLNode(name: GPXTags.keywords.rawValue, content: "keyword1 keyword2 keyword3")
+                    ]),
+                    XMLNode(name: GPXTags.track.rawValue, children: [
+                        XMLNode(name: GPXTags.name.rawValue, content: gpx.title),
+                        XMLNode(name: GPXTags.description.rawValue, content: "Non empty track"),
+                        XMLNode(name: GPXTags.trackSegment.rawValue,
+                                children: gpx.tracks[0].trackSegments[0].trackPoints.map {
+                                    $0.expectedXMLNode(withDate: true)
+                                }),
+                        XMLNode(name: GPXTags.trackSegment.rawValue,
+                                children: gpx.tracks[0].trackSegments[1].trackPoints.map {
+                                    $0.expectedXMLNode(withDate: true)
+                                })
+                    ]),
+                    XMLNode(name: GPXTags.track.rawValue, children: [
+                        XMLNode(name: GPXTags.name.rawValue, content: gpx.title),
+                        XMLNode(name: GPXTags.description.rawValue, content: "Non empty track"),
+                        XMLNode(name: GPXTags.trackSegment.rawValue,
+                                children: gpx.tracks[1].trackSegments[0].trackPoints.map {
+                                    $0.expectedXMLNode(withDate: true)
+                                }),
+                        XMLNode(name: GPXTags.trackSegment.rawValue,
+                                children: gpx.tracks[1].trackSegments[1].trackPoints.map {
+                                    $0.expectedXMLNode(withDate: true)
+                                })
+                    ])
+                ])
+
+        assertNodesAreEqual(expectedContent, result)
+    }
 
     func testItWillNotExportTheDatesFromTrack() {
         let gpx = GPX(date: Date(),

--- a/Tests/GPXKitTests/GPXParserTests.swift
+++ b/Tests/GPXKitTests/GPXParserTests.swift
@@ -45,8 +45,6 @@ class GPXParserTests: XCTestCase {
         """)
 
         let sut = try XCTUnwrap(result)
-        XCTAssertNoDifference("", sut.title)
-        XCTAssertNoDifference(nil, sut.description)
         XCTAssertNoDifference(expectedDate(for: "2020-03-17T11:27:02Z"), sut.date)
         XCTAssertNoDifference([], sut.trackPoints)
         XCTAssertNoDifference([], sut.graph.heightMap)
@@ -71,8 +69,8 @@ class GPXParserTests: XCTestCase {
             """
         )
 
-        XCTAssertNoDifference("Frühjahrsgeschlender ach wie schön!", result?.title)
-        XCTAssertNoDifference("Track description", result?.description)
+        XCTAssertNoDifference("Frühjahrsgeschlender ach wie schön!", result?.tracks[0].name!)
+        XCTAssertNoDifference("Track description", result?.tracks[0].description!)
     }
 
     func testParsingTrackSegmentsWithoutExtensions() throws {
@@ -91,7 +89,6 @@ class GPXParserTests: XCTestCase {
 
         try assertTracksAreEqual(GPX(
             date: expectedDate(for: "2020-03-18T12:39:47Z"),
-            title: "Haus- und Seenrunde Ausdauer",
             tracks: [GPXTrack(name: "Haus- und Seenrunde Ausdauer", trackSegments: [GPXSegment(trackPoints: expected)])]
         ), XCTUnwrap(result))
     }
@@ -120,8 +117,6 @@ class GPXParserTests: XCTestCase {
 
         try assertTracksAreEqual(GPX(
             date: expectedDate(for: "2020-03-18T12:39:47Z"),
-            title: "Haus- und Seenrunde Ausdauer",
-            description: "Track description",
             tracks: [GPXTrack(name: "Haus- und Seenrunde Ausdauer", description: "Track description", trackSegments: [GPXSegment(trackPoints: expected)])]
         ), XCTUnwrap(result))
     }
@@ -150,8 +145,6 @@ class GPXParserTests: XCTestCase {
 
         try assertTracksAreEqual(GPX(
             date: expectedDate(for: "2020-03-18T12:39:47Z"),
-            title: "Haus- und Seenrunde Ausdauer",
-            description: "Track description",
             tracks: [GPXTrack(name: "Haus- und Seenrunde Ausdauer", description: "Track description", trackSegments: [GPXSegment(trackPoints: expected)])]
         ), XCTUnwrap(result))
     }
@@ -190,7 +183,6 @@ class GPXParserTests: XCTestCase {
 
         try assertTracksAreEqual(GPX(
             date: nil,
-            title: "Haus- und Seenrunde Ausdauer",
             tracks: [GPXTrack(name: "Haus- und Seenrunde Ausdauer", trackSegments: [GPXSegment(trackPoints: expected)])]
         ), XCTUnwrap(result))
     }
@@ -225,7 +217,6 @@ class GPXParserTests: XCTestCase {
 
         try assertTracksAreEqual(GPX(
             date: nil,
-            title: "Haus- und Seenrunde Ausdauer",
             tracks: [GPXTrack(name: "Haus- und Seenrunde Ausdauer", trackSegments: [GPXSegment(trackPoints: expected)])]
         ), XCTUnwrap(result))
     }
@@ -443,7 +434,6 @@ class GPXParserTests: XCTestCase {
 
         try assertTracksAreEqual(GPX(
             date: nil,
-            title: "Haus- und Seenrunde Ausdauer",
             tracks: [GPXTrack(trackSegments: [GPXSegment(trackPoints: expected)])]
         ), XCTUnwrap(result))
     }
@@ -482,7 +472,6 @@ class GPXParserTests: XCTestCase {
         try assertTracksAreEqual(
             GPX(
                 date: nil,
-                title: "",
                 tracks: [GPXTrack(trackSegments: [GPXSegment(trackPoints: expected)])]
             ),
             XCTUnwrap(result)
@@ -599,7 +588,6 @@ class GPXParserTests: XCTestCase {
             try assertTracksAreEqual(
                 GPX(
                     date: nil,
-                    title: "",
                     tracks: expected
                 ),
                 XCTUnwrap(result)

--- a/Tests/GPXKitTests/GPXParserTests.swift
+++ b/Tests/GPXKitTests/GPXParserTests.swift
@@ -92,7 +92,7 @@ class GPXParserTests: XCTestCase {
         try assertTracksAreEqual(GPX(
             date: expectedDate(for: "2020-03-18T12:39:47Z"),
             title: "Haus- und Seenrunde Ausdauer",
-            tracks: [GPXTrack(trackSegments: [GPXSegment(trackPoints: expected)])]
+            tracks: [GPXTrack(name: "Haus- und Seenrunde Ausdauer", trackSegments: [GPXSegment(trackPoints: expected)])]
         ), XCTUnwrap(result))
     }
 
@@ -122,7 +122,7 @@ class GPXParserTests: XCTestCase {
             date: expectedDate(for: "2020-03-18T12:39:47Z"),
             title: "Haus- und Seenrunde Ausdauer",
             description: "Track description",
-            tracks: [GPXTrack(trackSegments: [GPXSegment(trackPoints: expected)])]
+            tracks: [GPXTrack(name: "Haus- und Seenrunde Ausdauer", description: "Track description", trackSegments: [GPXSegment(trackPoints: expected)])]
         ), XCTUnwrap(result))
     }
 
@@ -152,7 +152,7 @@ class GPXParserTests: XCTestCase {
             date: expectedDate(for: "2020-03-18T12:39:47Z"),
             title: "Haus- und Seenrunde Ausdauer",
             description: "Track description",
-            tracks: [GPXTrack(trackSegments: [GPXSegment(trackPoints: expected)])]
+            tracks: [GPXTrack(name: "Haus- und Seenrunde Ausdauer", description: "Track description", trackSegments: [GPXSegment(trackPoints: expected)])]
         ), XCTUnwrap(result))
     }
 
@@ -191,7 +191,7 @@ class GPXParserTests: XCTestCase {
         try assertTracksAreEqual(GPX(
             date: nil,
             title: "Haus- und Seenrunde Ausdauer",
-            tracks: [GPXTrack(trackSegments: [GPXSegment(trackPoints: expected)])]
+            tracks: [GPXTrack(name: "Haus- und Seenrunde Ausdauer", trackSegments: [GPXSegment(trackPoints: expected)])]
         ), XCTUnwrap(result))
     }
 
@@ -226,7 +226,7 @@ class GPXParserTests: XCTestCase {
         try assertTracksAreEqual(GPX(
             date: nil,
             title: "Haus- und Seenrunde Ausdauer",
-            tracks: [GPXTrack(trackSegments: [GPXSegment(trackPoints: expected)])]
+            tracks: [GPXTrack(name: "Haus- und Seenrunde Ausdauer", trackSegments: [GPXSegment(trackPoints: expected)])]
         ), XCTUnwrap(result))
     }
 

--- a/Tests/GPXKitTests/GPXParserTests.swift
+++ b/Tests/GPXKitTests/GPXParserTests.swift
@@ -8,7 +8,7 @@ import FoundationXML
 class GPXParserTests: XCTestCase {
     private var sut: GPXFileParser!
     private var parseError: GPXParserError?
-    private var result: GPXTrack?
+    private var result: GPX?
 
     private func parseXML(_ xml: String) {
         sut = GPXFileParser(xmlString: xml)
@@ -89,7 +89,7 @@ class GPXParserTests: XCTestCase {
             ),
         ]
 
-        try assertTracksAreEqual(GPXTrack(
+        try assertTracksAreEqual(GPX(
             date: expectedDate(for: "2020-03-18T12:39:47Z"),
             title: "Haus- und Seenrunde Ausdauer",
             trackPoints: expected
@@ -118,7 +118,7 @@ class GPXParserTests: XCTestCase {
             ),
         ]
 
-        try assertTracksAreEqual(GPXTrack(
+        try assertTracksAreEqual(GPX(
             date: expectedDate(for: "2020-03-18T12:39:47Z"),
             title: "Haus- und Seenrunde Ausdauer",
             description: "Track description",
@@ -148,7 +148,7 @@ class GPXParserTests: XCTestCase {
             ),
         ]
 
-        try assertTracksAreEqual(GPXTrack(
+        try assertTracksAreEqual(GPX(
             date: expectedDate(for: "2020-03-18T12:39:47Z"),
             title: "Haus- und Seenrunde Ausdauer",
             description: "Track description",
@@ -188,7 +188,7 @@ class GPXParserTests: XCTestCase {
             ),
         ]
 
-        try assertTracksAreEqual(GPXTrack(
+        try assertTracksAreEqual(GPX(
             date: nil,
             title: "Haus- und Seenrunde Ausdauer",
             trackPoints: expected
@@ -223,7 +223,7 @@ class GPXParserTests: XCTestCase {
             ),
         ]
 
-        try assertTracksAreEqual(GPXTrack(
+        try assertTracksAreEqual(GPX(
             date: nil,
             title: "Haus- und Seenrunde Ausdauer",
             trackPoints: expected
@@ -441,7 +441,7 @@ class GPXParserTests: XCTestCase {
             ),
         ]
 
-        try assertTracksAreEqual(GPXTrack(
+        try assertTracksAreEqual(GPX(
             date: nil,
             title: "Haus- und Seenrunde Ausdauer",
             trackPoints: expected
@@ -480,7 +480,7 @@ class GPXParserTests: XCTestCase {
         ]
 
         try assertTracksAreEqual(
-            GPXTrack(
+            GPX(
                 date: nil,
                 title: "",
                 trackPoints: expected
@@ -598,7 +598,7 @@ class GPXParserTests: XCTestCase {
             ]
 
             try assertTracksAreEqual(
-                GPXTrack(
+                GPX(
                     date: nil,
                     title: "",
                     trackPoints: expected

--- a/Tests/GPXKitTests/GPXParserTests.swift
+++ b/Tests/GPXKitTests/GPXParserTests.swift
@@ -92,7 +92,7 @@ class GPXParserTests: XCTestCase {
         try assertTracksAreEqual(GPX(
             date: expectedDate(for: "2020-03-18T12:39:47Z"),
             title: "Haus- und Seenrunde Ausdauer",
-            trackPoints: expected
+            tracks: [GPXTrack(trackSegments: [GPXSegment(trackPoints: expected)])]
         ), XCTUnwrap(result))
     }
 
@@ -122,7 +122,7 @@ class GPXParserTests: XCTestCase {
             date: expectedDate(for: "2020-03-18T12:39:47Z"),
             title: "Haus- und Seenrunde Ausdauer",
             description: "Track description",
-            trackPoints: expected
+            tracks: [GPXTrack(trackSegments: [GPXSegment(trackPoints: expected)])]
         ), XCTUnwrap(result))
     }
 
@@ -152,7 +152,7 @@ class GPXParserTests: XCTestCase {
             date: expectedDate(for: "2020-03-18T12:39:47Z"),
             title: "Haus- und Seenrunde Ausdauer",
             description: "Track description",
-            trackPoints: expected
+            tracks: [GPXTrack(trackSegments: [GPXSegment(trackPoints: expected)])]
         ), XCTUnwrap(result))
     }
 
@@ -191,7 +191,7 @@ class GPXParserTests: XCTestCase {
         try assertTracksAreEqual(GPX(
             date: nil,
             title: "Haus- und Seenrunde Ausdauer",
-            trackPoints: expected
+            tracks: [GPXTrack(trackSegments: [GPXSegment(trackPoints: expected)])]
         ), XCTUnwrap(result))
     }
 
@@ -226,7 +226,7 @@ class GPXParserTests: XCTestCase {
         try assertTracksAreEqual(GPX(
             date: nil,
             title: "Haus- und Seenrunde Ausdauer",
-            trackPoints: expected
+            tracks: [GPXTrack(trackSegments: [GPXSegment(trackPoints: expected)])]
         ), XCTUnwrap(result))
     }
 
@@ -444,7 +444,7 @@ class GPXParserTests: XCTestCase {
         try assertTracksAreEqual(GPX(
             date: nil,
             title: "Haus- und Seenrunde Ausdauer",
-            trackPoints: expected
+            tracks: [GPXTrack(trackSegments: [GPXSegment(trackPoints: expected)])]
         ), XCTUnwrap(result))
     }
 
@@ -483,7 +483,7 @@ class GPXParserTests: XCTestCase {
             GPX(
                 date: nil,
                 title: "",
-                trackPoints: expected
+                tracks: [GPXTrack(trackSegments: [GPXSegment(trackPoints: expected)])]
             ),
             XCTUnwrap(result)
         )
@@ -586,22 +586,21 @@ class GPXParserTests: XCTestCase {
             </gpx>
             """)
 
-            let expected = [
-                GPXPoint(
-                    coordinate: Coordinate(latitude: 51.2760600, longitude: 12.3769500, elevation: 114.2),
-                    date: nil
-                ),
-                GPXPoint(
-                    coordinate: Coordinate(latitude: 51.2760420, longitude: 12.3769760, elevation: 114.0),
-                    date: nil
-                ),
-            ]
+            let expected = [GPXTrack(trackSegments: 
+                                [GPXSegment(trackPoints: [GPXPoint(
+                                    coordinate: Coordinate(latitude: 51.2760600, longitude: 12.3769500, elevation: 114.2),
+                                    date: nil)]),
+                                 GPXSegment(trackPoints: [GPXPoint(
+                                    coordinate: Coordinate(latitude: 51.2760420, longitude: 12.3769760, elevation: 114.0),
+                                    date: nil)])
+                                ])
+                            ]
 
             try assertTracksAreEqual(
                 GPX(
                     date: nil,
                     title: "",
-                    trackPoints: expected
+                    tracks: expected
                 ),
                 XCTUnwrap(result)
             )

--- a/Tests/GPXKitTests/GPXParserTests.swift
+++ b/Tests/GPXKitTests/GPXParserTests.swift
@@ -79,11 +79,11 @@ class GPXParserTests: XCTestCase {
         parseXML(testXMLWithoutExtensions)
 
         let expected = [
-            TrackPoint(
+            GPXPoint(
                 coordinate: Coordinate(latitude: 51.2760600, longitude: 12.3769500, elevation: 114.2),
                 date: expectedDate(for: "2020-07-03T13:20:50.000Z")
             ),
-            TrackPoint(
+            GPXPoint(
                 coordinate: Coordinate(latitude: 51.2760420, longitude: 12.3769760, elevation: 114.0),
                 date: expectedDate(for: "2020-03-18T12:45:48Z")
             ),
@@ -100,7 +100,7 @@ class GPXParserTests: XCTestCase {
         parseXML(testXMLData)
 
         let expected = [
-            TrackPoint(
+            GPXPoint(
                 coordinate: Coordinate(latitude: 51.2760600, longitude: 12.3769500, elevation: 114.2),
                 date: expectedDate(for: "2020-03-18T12:39:47Z"),
                 power: Measurement<UnitPower>(value: 42, unit: .watts),
@@ -108,7 +108,7 @@ class GPXParserTests: XCTestCase {
                 heartrate: 97,
                 temperature: Measurement<UnitTemperature>(value: 21, unit: .celsius)
             ),
-            TrackPoint(
+            GPXPoint(
                 coordinate: Coordinate(latitude: 51.2760420, longitude: 12.3769760, elevation: 114.0),
                 date: expectedDate(for: "2020-03-18T12:39:48Z"),
                 power: Measurement<UnitPower>(value: 272, unit: .watts),
@@ -130,7 +130,7 @@ class GPXParserTests: XCTestCase {
         parseXML(namespacedTestXMLData)
 
         let expected = [
-            TrackPoint(
+            GPXPoint(
                 coordinate: Coordinate(latitude: 51.2760600, longitude: 12.3769500, elevation: 114.2),
                 date: expectedDate(for: "2020-03-18T12:39:47Z"),
                 power: Measurement<UnitPower>(value: 166, unit: .watts),
@@ -138,7 +138,7 @@ class GPXParserTests: XCTestCase {
                 heartrate: 90,
                 temperature: Measurement<UnitTemperature>(value: 22, unit: .celsius)
             ),
-            TrackPoint(
+            GPXPoint(
                 coordinate: Coordinate(latitude: 51.2760420, longitude: 12.3769760, elevation: 114.0),
                 date: expectedDate(for: "2020-03-18T12:39:48Z"),
                 power: Measurement<UnitPower>(value: 230, unit: .watts),
@@ -178,11 +178,11 @@ class GPXParserTests: XCTestCase {
         """)
 
         let expected = [
-            TrackPoint(
+            GPXPoint(
                 coordinate: Coordinate(latitude: 51.2760600, longitude: 12.3769500, elevation: 114.2),
                 date: nil
             ),
-            TrackPoint(
+            GPXPoint(
                 coordinate: Coordinate(latitude: 51.2760420, longitude: 12.3769760, elevation: 114.0),
                 date: nil
             ),
@@ -213,11 +213,11 @@ class GPXParserTests: XCTestCase {
         """)
 
         let expected = [
-            TrackPoint(
+            GPXPoint(
                 coordinate: Coordinate(latitude: 51.2760600, longitude: 12.3769500, elevation: 0),
                 date: nil
             ),
-            TrackPoint(
+            GPXPoint(
                 coordinate: Coordinate(latitude: 51.2760420, longitude: 12.3769760, elevation: 0),
                 date: nil
             ),
@@ -431,11 +431,11 @@ class GPXParserTests: XCTestCase {
         """)
 
         let expected = [
-            TrackPoint(
+            GPXPoint(
                 coordinate: Coordinate(latitude: 51.2760600, longitude: 12.3769500, elevation: 114.2),
                 date: nil
             ),
-            TrackPoint(
+            GPXPoint(
                 coordinate: Coordinate(latitude: 51.2760420, longitude: 12.3769760, elevation: 114),
                 date: nil
             ),
@@ -469,11 +469,11 @@ class GPXParserTests: XCTestCase {
         """)
 
         let expected = [
-            TrackPoint(
+            GPXPoint(
                 coordinate: Coordinate(latitude: 51.2760600, longitude: 12.3769500, elevation: 114.2),
                 date: nil
             ),
-            TrackPoint(
+            GPXPoint(
                 coordinate: Coordinate(latitude: 51.2760420, longitude: 12.3769760, elevation: 114.0),
                 date: nil
             ),
@@ -587,11 +587,11 @@ class GPXParserTests: XCTestCase {
             """)
 
             let expected = [
-                TrackPoint(
+                GPXPoint(
                     coordinate: Coordinate(latitude: 51.2760600, longitude: 12.3769500, elevation: 114.2),
                     date: nil
                 ),
-                TrackPoint(
+                GPXPoint(
                     coordinate: Coordinate(latitude: 51.2760420, longitude: 12.3769760, elevation: 114.0),
                     date: nil
                 ),

--- a/Tests/GPXKitTests/GPXTrackTests.swift
+++ b/Tests/GPXKitTests/GPXTrackTests.swift
@@ -18,7 +18,7 @@ final class GPXTrackTests: XCTestCase {
     private func givenTrack(with coordinates: [Coordinate]) {
         sut = GPX(
             title: "Track",
-            trackPoints: coordinates.map { GPXPoint(coordinate: $0) }
+            tracks: [GPXTrack(trackSegments: [GPXSegment(trackPoints: coordinates.map { GPXPoint(coordinate: $0) })])]
         )
     }
 
@@ -68,13 +68,14 @@ final class GPXTrackTests: XCTestCase {
         let second: Coordinate = first.offset(distance: 100, grade: 0.2)
         let third: Coordinate = second.offset(distance: 100, grade: -0.3)
         let fourth: Coordinate = third.offset(distance: 50, grade: 0.06)
-        sut = try GPX(title: "Track", trackPoints: [
+        
+        sut = try GPX(title: "Track", tracks: [GPXTrack(trackSegments: [GPXSegment(trackPoints: [
             start,
             first,
             second,
             third,
             fourth
-        ].map { GPXPoint(coordinate: $0) }, elevationSmoothing: .segmentation(50))
+        ].map { GPXPoint(coordinate: $0) })])] , elevationSmoothing: .segmentation(50))
 
         let expected: [GradeSegment] = try [
             XCTUnwrap(.init(start: 0, end: 100, elevationAtStart: 100, elevationAtEnd: 109.98)),

--- a/Tests/GPXKitTests/GPXTrackTests.swift
+++ b/Tests/GPXKitTests/GPXTrackTests.swift
@@ -18,7 +18,7 @@ final class GPXTrackTests: XCTestCase {
     private func givenTrack(with coordinates: [Coordinate]) {
         sut = GPX(
             title: "Track",
-            trackPoints: coordinates.map { TrackPoint(coordinate: $0) }
+            trackPoints: coordinates.map { GPXPoint(coordinate: $0) }
         )
     }
 
@@ -74,7 +74,7 @@ final class GPXTrackTests: XCTestCase {
             second,
             third,
             fourth
-        ].map { TrackPoint(coordinate: $0) }, elevationSmoothing: .segmentation(50))
+        ].map { GPXPoint(coordinate: $0) }, elevationSmoothing: .segmentation(50))
 
         let expected: [GradeSegment] = try [
             XCTUnwrap(.init(start: 0, end: 100, elevationAtStart: 100, elevationAtEnd: 109.98)),

--- a/Tests/GPXKitTests/GPXTrackTests.swift
+++ b/Tests/GPXKitTests/GPXTrackTests.swift
@@ -4,7 +4,7 @@ import GPXKit
 import CustomDump
 
 final class GPXTrackTests: XCTestCase {
-    var sut: GPXTrack!
+    var sut: GPX!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -16,7 +16,7 @@ final class GPXTrackTests: XCTestCase {
     }
 
     private func givenTrack(with coordinates: [Coordinate]) {
-        sut = GPXTrack(
+        sut = GPX(
             title: "Track",
             trackPoints: coordinates.map { TrackPoint(coordinate: $0) }
         )
@@ -68,7 +68,7 @@ final class GPXTrackTests: XCTestCase {
         let second: Coordinate = first.offset(distance: 100, grade: 0.2)
         let third: Coordinate = second.offset(distance: 100, grade: -0.3)
         let fourth: Coordinate = third.offset(distance: 50, grade: 0.06)
-        sut = try GPXTrack(title: "Track", trackPoints: [
+        sut = try GPX(title: "Track", trackPoints: [
             start,
             first,
             second,

--- a/Tests/GPXKitTests/GPXTrackTests.swift
+++ b/Tests/GPXKitTests/GPXTrackTests.swift
@@ -17,7 +17,6 @@ final class GPXTrackTests: XCTestCase {
 
     private func givenTrack(with coordinates: [Coordinate]) {
         sut = GPX(
-            title: "Track",
             tracks: [GPXTrack(trackSegments: [GPXSegment(trackPoints: coordinates.map { GPXPoint(coordinate: $0) })])]
         )
     }
@@ -69,7 +68,7 @@ final class GPXTrackTests: XCTestCase {
         let third: Coordinate = second.offset(distance: 100, grade: -0.3)
         let fourth: Coordinate = third.offset(distance: 50, grade: 0.06)
         
-        sut = try GPX(title: "Track", tracks: [GPXTrack(trackSegments: [GPXSegment(trackPoints: [
+        sut = try GPX(tracks: [GPXTrack(trackSegments: [GPXSegment(trackPoints: [
             start,
             first,
             second,

--- a/Tests/GPXKitTests/TestFixtures.swift
+++ b/Tests/GPXKitTests/TestFixtures.swift
@@ -141,7 +141,7 @@ let namespacedTestXMLData = """
         </gpx>
         """
 
-let testTrack = GPXTrack(date: expectedDate(for: "2020-03-18T12:39:47Z"),
+let testTrack = GPX(date: expectedDate(for: "2020-03-18T12:39:47Z"),
                          title: "Haus- und Seenrunde Ausdauer",
                          trackPoints: [
                             TrackPoint(coordinate: Coordinate(latitude: 51.2760600, longitude: 12.3769500, elevation: 114.2),
@@ -150,7 +150,7 @@ let testTrack = GPXTrack(date: expectedDate(for: "2020-03-18T12:39:47Z"),
                                        date: expectedDate(for: "2020-03-18T12:45:48Z"))
                          ])
 
-let testTrackWithoutTime = GPXTrack(date: nil,
+let testTrackWithoutTime = GPX(date: nil,
                                     title: "Test track without time",
                                         description: "Description",
                                     trackPoints: [

--- a/Tests/GPXKitTests/TestFixtures.swift
+++ b/Tests/GPXKitTests/TestFixtures.swift
@@ -143,7 +143,8 @@ let namespacedTestXMLData = """
 
 let testTrack = GPX(date: expectedDate(for: "2020-03-18T12:39:47Z"),
                          title: "Haus- und Seenrunde Ausdauer",
-                         tracks: [GPXTrack(trackSegments: [GPXSegment(trackPoints: [
+                         tracks: [GPXTrack(name: "Haus- und Seenrunde Ausdauer",
+                            trackSegments: [GPXSegment(trackPoints: [
                             GPXPoint(coordinate: Coordinate(latitude: 51.2760600, longitude: 12.3769500, elevation: 114.2),
                                        date: expectedDate(for: "2020-07-03T13:20:50.000Z")),
                             GPXPoint(coordinate: Coordinate(latitude: 51.2760420, longitude: 12.3769760, elevation: 114.0),
@@ -154,7 +155,7 @@ let testTrack = GPX(date: expectedDate(for: "2020-03-18T12:39:47Z"),
 let testTrackWithoutTime = GPX(date: nil,
                                     title: "Test track without time",
                                     description: "Description",
-                                    tracks: [GPXTrack(trackSegments: [GPXSegment(trackPoints: [
+                               tracks: [GPXTrack(name: "Test track without time", description: "Description", trackSegments: [GPXSegment(trackPoints: [
                                         GPXPoint(coordinate: Coordinate(latitude: 51.2760600, longitude: 12.3769500, elevation: 114.2),
                                                    date: nil),
                                         GPXPoint(coordinate: Coordinate(latitude: 51.2760420, longitude: 12.3769760, elevation: 114.0),

--- a/Tests/GPXKitTests/TestFixtures.swift
+++ b/Tests/GPXKitTests/TestFixtures.swift
@@ -142,7 +142,6 @@ let namespacedTestXMLData = """
         """
 
 let testTrack = GPX(date: expectedDate(for: "2020-03-18T12:39:47Z"),
-                         title: "Haus- und Seenrunde Ausdauer",
                          tracks: [GPXTrack(name: "Haus- und Seenrunde Ausdauer",
                             trackSegments: [GPXSegment(trackPoints: [
                             GPXPoint(coordinate: Coordinate(latitude: 51.2760600, longitude: 12.3769500, elevation: 114.2),
@@ -153,8 +152,6 @@ let testTrack = GPX(date: expectedDate(for: "2020-03-18T12:39:47Z"),
 )
 
 let testTrackWithoutTime = GPX(date: nil,
-                                    title: "Test track without time",
-                                    description: "Description",
                                tracks: [GPXTrack(name: "Test track without time", description: "Description", trackSegments: [GPXSegment(trackPoints: [
                                         GPXPoint(coordinate: Coordinate(latitude: 51.2760600, longitude: 12.3769500, elevation: 114.2),
                                                    date: nil),

--- a/Tests/GPXKitTests/TestFixtures.swift
+++ b/Tests/GPXKitTests/TestFixtures.swift
@@ -143,22 +143,23 @@ let namespacedTestXMLData = """
 
 let testTrack = GPX(date: expectedDate(for: "2020-03-18T12:39:47Z"),
                          title: "Haus- und Seenrunde Ausdauer",
-                         trackPoints: [
+                         tracks: [GPXTrack(trackSegments: [GPXSegment(trackPoints: [
                             GPXPoint(coordinate: Coordinate(latitude: 51.2760600, longitude: 12.3769500, elevation: 114.2),
                                        date: expectedDate(for: "2020-07-03T13:20:50.000Z")),
                             GPXPoint(coordinate: Coordinate(latitude: 51.2760420, longitude: 12.3769760, elevation: 114.0),
                                        date: expectedDate(for: "2020-03-18T12:45:48Z"))
-                         ])
+                         ])])]
+)
 
 let testTrackWithoutTime = GPX(date: nil,
                                     title: "Test track without time",
-                                        description: "Description",
-                                    trackPoints: [
+                                    description: "Description",
+                                    tracks: [GPXTrack(trackSegments: [GPXSegment(trackPoints: [
                                         GPXPoint(coordinate: Coordinate(latitude: 51.2760600, longitude: 12.3769500, elevation: 114.2),
                                                    date: nil),
                                         GPXPoint(coordinate: Coordinate(latitude: 51.2760420, longitude: 12.3769760, elevation: 114.0),
                                                    date: nil)
-                                    ])
+                                    ])])])
 
 let testXMLDataContainingWaypoint = """
         <?xml version="1.0" encoding="UTF-8"?>

--- a/Tests/GPXKitTests/TestFixtures.swift
+++ b/Tests/GPXKitTests/TestFixtures.swift
@@ -144,9 +144,9 @@ let namespacedTestXMLData = """
 let testTrack = GPX(date: expectedDate(for: "2020-03-18T12:39:47Z"),
                          title: "Haus- und Seenrunde Ausdauer",
                          trackPoints: [
-                            TrackPoint(coordinate: Coordinate(latitude: 51.2760600, longitude: 12.3769500, elevation: 114.2),
+                            GPXPoint(coordinate: Coordinate(latitude: 51.2760600, longitude: 12.3769500, elevation: 114.2),
                                        date: expectedDate(for: "2020-07-03T13:20:50.000Z")),
-                            TrackPoint(coordinate: Coordinate(latitude: 51.2760420, longitude: 12.3769760, elevation: 114.0),
+                            GPXPoint(coordinate: Coordinate(latitude: 51.2760420, longitude: 12.3769760, elevation: 114.0),
                                        date: expectedDate(for: "2020-03-18T12:45:48Z"))
                          ])
 
@@ -154,9 +154,9 @@ let testTrackWithoutTime = GPX(date: nil,
                                     title: "Test track without time",
                                         description: "Description",
                                     trackPoints: [
-                                        TrackPoint(coordinate: Coordinate(latitude: 51.2760600, longitude: 12.3769500, elevation: 114.2),
+                                        GPXPoint(coordinate: Coordinate(latitude: 51.2760600, longitude: 12.3769500, elevation: 114.2),
                                                    date: nil),
-                                        TrackPoint(coordinate: Coordinate(latitude: 51.2760420, longitude: 12.3769760, elevation: 114.0),
+                                        GPXPoint(coordinate: Coordinate(latitude: 51.2760420, longitude: 12.3769760, elevation: 114.0),
                                                    date: nil)
                                     ])
 

--- a/Tests/GPXKitTests/TestHelpers.swift
+++ b/Tests/GPXKitTests/TestHelpers.swift
@@ -167,8 +167,8 @@ extension XCTest {
     }
 
     func assertTracksAreEqual(
-        _ expected: GPXTrack,
-        _ actual: GPXTrack,
+        _ expected: GPX,
+        _ actual: GPX,
         file: StaticString = #filePath,
         line: UInt = #line
     ) {

--- a/Tests/GPXKitTests/TestHelpers.swift
+++ b/Tests/GPXKitTests/TestHelpers.swift
@@ -173,8 +173,6 @@ extension XCTest {
         line: UInt = #line
     ) {
         assertDatesEqual(expected.date, actual.date, file: file, line: line)
-        XCTAssertNoDifference(expected.title, actual.title, file: file, line: line)
-        XCTAssertNoDifference(expected.description, actual.description, file: file, line: line)
         XCTAssertNoDifference(expected.keywords, actual.keywords, file: file, line: line)
         XCTAssertNoDifference(expected.tracks, actual.tracks, file: file, line: line)
         XCTAssertNoDifference(expected.graph, actual.graph, file: file, line: line)

--- a/Tests/GPXKitTests/TestHelpers.swift
+++ b/Tests/GPXKitTests/TestHelpers.swift
@@ -54,11 +54,11 @@ func expectedString(for date: Date) -> String {
     return iso8601Formatter.string(from: date)
 }
 
-func givenTrackPoints(_ count: Int) -> [TrackPoint] {
+func givenTrackPoints(_ count: Int) -> [GPXPoint] {
     let date = Date()
 
     return (1..<count).map { sec in
-        TrackPoint(coordinate: .random, date: date + TimeInterval(sec))
+        GPXPoint(coordinate: .random, date: date + TimeInterval(sec))
     }
 }
 
@@ -125,7 +125,7 @@ extension TestGPXPoint {
 }
 
 
-extension TrackPoint {
+extension GPXPoint {
     func expectedXMLNode(withDate: Bool = false) -> GPXKit.XMLNode {
         XMLNode(name: GPXTags.trackPoint.rawValue,
                 attributes: [

--- a/Tests/GPXKitTests/TestHelpers.swift
+++ b/Tests/GPXKitTests/TestHelpers.swift
@@ -176,7 +176,7 @@ extension XCTest {
         XCTAssertNoDifference(expected.title, actual.title, file: file, line: line)
         XCTAssertNoDifference(expected.description, actual.description, file: file, line: line)
         XCTAssertNoDifference(expected.keywords, actual.keywords, file: file, line: line)
-        XCTAssertNoDifference(expected.trackPoints, actual.trackPoints, file: file, line: line)
+        XCTAssertNoDifference(expected.tracks, actual.tracks, file: file, line: line)
         XCTAssertNoDifference(expected.graph, actual.graph, file: file, line: line)
         XCTAssertNoDifference(expected.bounds, actual.bounds, file: file, line: line)
     }

--- a/Tests/GPXKitTests/TrackGraphTests.swift
+++ b/Tests/GPXKitTests/TrackGraphTests.swift
@@ -22,8 +22,8 @@ final class TrackGraphTests: XCTestCase {
         super.tearDown()
     }
 
-    func givenAPoint(latitude: Double, longitude: Double, elevation: Double) -> TrackPoint {
-        return TrackPoint(
+    func givenAPoint(latitude: Double, longitude: Double, elevation: Double) -> GPXPoint {
+        return GPXPoint(
             coordinate: Coordinate(latitude: latitude, longitude: longitude, elevation: elevation),
             date: Date()
         )
@@ -102,7 +102,7 @@ final class TrackGraphTests: XCTestCase {
     }
 
     func testInitializationFromGPX() throws {
-        let points: [TrackPoint] = [
+        let points: [GPXPoint] = [
             givenAPoint(latitude: 51.2763320, longitude: 12.3767670, elevation: 1),
             givenAPoint(latitude: 51.2763700, longitude: 12.3767550, elevation: 1),
             givenAPoint(latitude: 51.2764100, longitude: 12.3767400, elevation: 1),
@@ -432,7 +432,7 @@ final class TrackGraphTests: XCTestCase {
             second,
             third,
             fourth,
-        ].map { TrackPoint(coordinate: $0) }, elevationSmoothing: .segmentation(50))
+        ].map { GPXPoint(coordinate: $0) }, elevationSmoothing: .segmentation(50))
 
         let expected: [GradeSegment] = try [
             XCTUnwrap(.init(start: 0, end: 100, grade: 0.1, elevationAtStart: 100)),


### PR DESCRIPTION
Here finally comes my suggestion for supporting multiple tracks with multiple segments according to the GPX Schema (https://www.topografix.com/GPX/1/1/). Unfortunately, API changes are necessary for this (titles and descriptions moved to individual tracks). 