### PR TITLE
Remove "with no dependencies" from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GPXKit
 
-A library for parsing and exporting GPX files with no dependencies besides Foundation.
+A library for parsing and exporting GPX files.
 
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fmmllr%2FGPXKit%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/mmllr/GPXKit)  
 [![](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fmmllr%2FGPXKit%2Fbadge%3Ftype%3Dplatforms)](https://swiftpackageindex.com/mmllr/GPXKit)


### PR DESCRIPTION
Since this package depends on several other OSS Swift packages, this claim seems misleading/out of date. Here is the change to remove it from the README. It is also in the project's About section and should be removed from there.